### PR TITLE
fix: epsilon transitions included as reachable (#8)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v1.0.2 (2024-09-29)
+
+### Fix
+
+ - `get_reachable_states` missing epsilon transitions (#8).
+
 ## v1.0.1 (2024-04-15)
 
 ### Fix

--- a/demo/demo.ml
+++ b/demo/demo.ml
@@ -63,6 +63,8 @@ let main () =
   (* Convert REs to NFAs *)
   let nfa1 = Nfa.re_to_nfa re1'
   and nfa2 = Nfa.re_to_nfa re2' in
+  (* Prune NFAs to reachable states *)
+  Nfa.prune nfa1; Nfa.prune nfa2;
   (* Merge the NFA alphabets *)
   Nfa.merge_alphabets nfa1 nfa2;
   (* Convert NFAs to DFAs *)

--- a/lib/adt.ml
+++ b/lib/adt.ml
@@ -75,7 +75,7 @@ let get_reachable_states m =
           List.fold_left
             (fun acc2 a -> Utils.list_union acc2 (get_next_states m s a))
             acc
-            m.alphabet)
+            ("ε"::m.alphabet))
         marked
         marked
     in


### PR DESCRIPTION
Fixes the issue causing crash in #8 

`get_reachable_states` in `Adt` module now considers epsilon transitions as reachable.